### PR TITLE
Fixes to normal systematics in the fit

### DIFF
--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -548,10 +548,6 @@ def main():
     indata = inputdata.FitInputData(args.filename, args.pseudoData)
     ifitter = fitter.Fitter(indata, args)
 
-    # physics models for observables and transformations
-    if len(args.physicsModel) == 0:
-        # if no model is explicitly added, fall back to Basemodel
-        args.physicsModel = [["Basemodel"]]
     models = []
     for margs in args.physicsModel:
         model = ph.instance_from_class(margs[0], indata, *margs[1:])

--- a/bin/combinetf2_plot_inputdata.py
+++ b/bin/combinetf2_plot_inputdata.py
@@ -74,7 +74,7 @@ def parseArgs():
         "--normToData", action="store_true", help="Normalize MC to data", default=False
     )
     parser.add_argument(
-        "--pseuodata",
+        "--pseudodata",
         type=str,
         default=None,
         help="Pseuododata name to plot instead of data.",
@@ -600,7 +600,7 @@ def main():
     global logger
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
-    indata = inputdata.FitInputData(args.infile, pseudodata=args.pseuodata)
+    indata = inputdata.FitInputData(args.infile, pseudodata=args.pseudodata)
 
     debug = debugdata.FitDebugData(indata)
 

--- a/bin/combinetf2_plot_inputdata.py
+++ b/bin/combinetf2_plot_inputdata.py
@@ -71,7 +71,13 @@ def parseArgs():
         help="List of hists to plot; dash separated for unrolled hists",
     )
     parser.add_argument(
-        "--normToData", action="store_true", help="Normalize MC to data"
+        "--normToData", action="store_true", help="Normalize MC to data", default=False
+    )
+    parser.add_argument(
+        "--pseuodata",
+        type=str,
+        default=None,
+        help="Pseuododata name to plot instead of data.",
     )
     parser.add_argument(
         "--dataName", type=str, default="Data", help="Data name for plot labeling"
@@ -594,7 +600,7 @@ def main():
     global logger
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
-    indata = inputdata.FitInputData(args.infile)
+    indata = inputdata.FitInputData(args.infile, pseudodata=args.pseuodata)
 
     debug = debugdata.FitDebugData(indata)
 

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1046,11 +1046,6 @@ class Fitter:
             elif self.indata.systematic_type == "normal":
                 normcentral = norm * ernorm + logsnorm
                 nexpcentral = tf.reduce_sum(normcentral, axis=-1)
-                nexpcentral = tf.where(
-                    nexpcentral <= 0,
-                    tf.constant(np.finfo(np.float64).eps, dtype=nexpcentral.dtype),
-                    nexpcentral,
-                )
 
         return nexpcentral, normcentral
 


### PR DESCRIPTION
- normal type systematics could cause issues in the fit since they could result in negative yields. This issue is avoided by bounding the log value to an infinitesimal small value
- added a protection to the fitter in case the loss went to nan, else it would infinitely and aimlessly iterate
- removed the default physics model in the fit
- added option to plot pseudodata instead of data in combinetf2_plot_inputdata.py